### PR TITLE
Allow dictionary arrays and hyphenates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ console.log(dict.lookup('hei'));
 /*
 { found: false,
   word: 'hei',
-  suggestions: 
+  suggestions:
    [ { found: true, word: 'he', rank: 38410 },
      { found: true, word: 'her', rank: 14182 },
      { found: true, word: 'hey', rank: 529 },
@@ -42,7 +42,7 @@ console.log(dict.lookup('yellows'));
 /*
 { found: false,
   word: 'yellows',
-  suggestions: 
+  suggestions:
    [ { found: true, word: 'yellow', rank: 380 },
      { found: true, word: 'yellowy', rank: 2 },
      { found: true, word: 'fellow', rank: 551 },
@@ -79,6 +79,21 @@ console.log(dict.search('manu', {depth: 8}));
 
 ```
 
+## Custom Dictionaries
+
+If you'd prefer to receive suggestions on people or place names (for which there is no apparent "rank"), you can simply supply an array of those names.
+
+```
+var spelling = require('./');
+
+var dict = new spelling(['wilkes-barre', 'philadelphia']);
+
+console.log(dict.lookup('wilkes barre'));
+//{ found: false, word: 'wilkes-barre', rank: 1 }
+```
+
+Otherwise, the dictionary format is one big string of pairs, space delimited: `word1 rank1 word2 rank2 [...]` where the ranks are integers.
+
 # API
 ## .lookup(word, [opts])
 
@@ -106,7 +121,7 @@ console.log(dict.lookup('hei'));
 /*
 { found: false,
   word: 'hei',
-  suggestions: 
+  suggestions:
    [ { found: true, word: 'he', rank: 38410 },
      { found: true, word: 'her', rank: 14182 },
      { found: true, word: 'hey', rank: 529 },

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 /*jslint plusplus: true */
 'use strict';
 
+
 module.exports = function (dictionary) {
 
     var dict = [],
-        ALPHABETS = "abcdefghijklmnopqrstuvwxyz'".split(""),
+        ALPHABETS = "abcdefghijklmnopqrstuvwxyz'-".split(""),
         ETX = String.fromCharCode(3);   //End of Text Character
 
 

--- a/index.js
+++ b/index.js
@@ -270,7 +270,8 @@ module.exports = function (dictionary) {
 
     function build() {
 
-        if (dictionary !== undefined && typeof dictionary === 'string') {
+	if (dictionary === undefined) return;
+        if (typeof dictionary === 'string') {
             var i,
                 words = dictionary.split(' ');
 
@@ -279,7 +280,12 @@ module.exports = function (dictionary) {
             }
 
             dictionary = '';
-        }
+        } else if (Array.isArray(dictionary)) {
+	    dictionary.forEach(function (elem) {
+		insert(elem, 1);
+	    });
+	    dictionary = '';
+	}
     }
 
     build();

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 module.exports = function (dictionary) {
 
     var dict = [],
-        ALPHABETS = "abcdefghijklmnopqrstuvwxyz'-".split(""),
+        ALPHABETS = "abcdefghijklmnopqrstuvwxyz'- ".split(""),
         ETX = String.fromCharCode(3);   //End of Text Character
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -204,5 +204,15 @@ describe('Test loading and building the dictionary', function () {
         expect(dict.lookup('are').found).to.equal(true);
     });
 
-});
+    it('words lookup on an array-based dictionary', function () {
+        var dict = new spelling(['wilkes-barre', 'philadelphia']);
 
+        expect(dict.lookup('hello').found).to.equal(false);
+        expect(dict.lookup('wilkes-barre').found).to.equal(true);
+	var result = dict.lookup('wilkes barre')
+        expect(result.found).to.equal(false);
+        expect(result.suggestions[0].word).to.equal('wilkes-barre');
+
+    });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -209,9 +209,30 @@ describe('Test loading and building the dictionary', function () {
 
         expect(dict.lookup('hello').found).to.equal(false);
         expect(dict.lookup('wilkes-barre').found).to.equal(true);
-	var result = dict.lookup('wilkes barre')
+	    var result = dict.lookup('wilkes barre')
         expect(result.found).to.equal(false);
         expect(result.suggestions[0].word).to.equal('wilkes-barre');
+
+    });
+
+    it("doesn't attempt to handle trailing spaces", function () {
+        var dict = new spelling(['cape cod', 'hyannis']);
+
+        expect(dict.lookup('cape-cod').found).to.equal(false);
+        expect(dict.lookup('cape cod').found).to.equal(true);
+	    var result = dict.lookup('cape cod ')
+        //expect(result.found).to.equal(false);
+        expect(result.suggestions).to.equal(undefined);
+    });
+
+    it('handles hyphens', function () {
+        var dict = new spelling(['cape cod', 'hyannis']);
+
+        expect(dict.lookup('cape-cod').found).to.equal(false);
+        expect(dict.lookup('cape cod').found).to.equal(true);
+	    var result = dict.lookup('cape-cod')
+        expect(result.found).to.equal(false);
+        expect(result.suggestions[0].word).to.equal('cape cod');
 
     });
 


### PR DESCRIPTION
These changes support custom dictionaries, specifically aimed at proper names (like people or places).  In such a system, the "rank" means very little; I expand the constructor to accept arrays, which creates a spell checker that considers all array elements to be words of equal rank.

Additionally, I expand the allowable characters to include the hyphen and space.

Automated tests added.

Fixes #1 